### PR TITLE
Fix iso date that causes infinite loop

### DIFF
--- a/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
+++ b/webapp/portlet/src/main/webapp/vue-apps/common/js/DateUtil.js
@@ -55,7 +55,7 @@ export function getISODate(dateObj) {
   if (!dateObj) {
     return null;
   }
-  return dateObj.toISOString().substr(0,10);
+  return new Date(dateObj.getTime() - (dateObj.getTimezoneOffset() * 60000)).toISOString().substring(0,10);
 }
 
 /**


### PR DESCRIPTION
When create new task on task addon a infinite loop is caused by the iso date without timezone.